### PR TITLE
Fix for C900000008-693

### DIFF
--- a/gpas_uploader/UploadBatch.py
+++ b/gpas_uploader/UploadBatch.py
@@ -48,7 +48,7 @@ class UploadBatch:
         # back slash (\\) at runtime inside the regular expression, so the regular expression matches
         # Windows-like paths correctly. At the same time string representation of upload_csv needs to replace
         # its back slashes with escaped back slashes, which on code level looks as replacent of \\ with \\\\.
-        assert re.match("^[A-Za-z0-9-_/.:\\\\]+$", str(upload_csv).replace("\\", "\\\\")), "filename can only contain characters A-Za-z0-9-_./:\\"
+        assert re.match("^[A-Za-z0-9-_/.:\\\\ ]+$", str(upload_csv).replace("\\", "\\\\")), "filename can only contain characters A-Za-z0-9-_./:\\"
 
         # instance variables
         self.upload_csv = Path(upload_csv)


### PR DESCRIPTION
This is a fix for https://oc-collab.gc3.ocs.oraclecloud.com/browse/C900000008-693.

**Problem**

Gpas-uploader doesn't accept spaces inside a file path (token.json or csv metadata). There can be two scenarios:

- The file path with spaces is not enclosed with quotes (which is wrong - paths with spaces must be enclosed with quotes/double quotes to avoid ambiguity). In this case gpas-uploader reacts correctly - it shows "unknown option"- and "how to use"-like messages.

- The file path with spaces is enclosed with quotes (which is correct). In this case gpas-uploader shows **incorrect** behavior - it fails its path correctness check, which means that its validation mechanism doesn't accept spaces inside a path:

**Expected Behavior**

Gpas-uploader accepts file paths enclosed with quotes with spaces inside.
